### PR TITLE
Bump highlight.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "chalk": "^4.0.0",
-    "highlight.js": "~10.2.0",
+    "highlight.js": "~10.4.1",
     "lowlight": "~1.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To get rid of this warning
`warning emphasize > highlight.js@10.2.1: Potential vulnerability. Please upgrade to @latest`

I don't think there were any breaking changes between 10.2.* and 10.4.*?